### PR TITLE
fix tile url: use osm tileserver instead of wikimedia

### DIFF
--- a/critical-snake/bikemap.js
+++ b/critical-snake/bikemap.js
@@ -22,9 +22,10 @@ function createBikeMap(L, options) {
   };
 
   bikeMap.addLayer(L.tileLayer(
-    'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png',
-    { attribution: `<a href="${wiki.url}">${wiki.title}</a> | ` +
-                   `&copy; <a href="${osm.url}">${osm.title}</a>` }));
+    'https://{s}.tile.osm.org/{z}/{x}/{y}.png',
+    { attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors' }
+  ));
+
 
   const disableClickThrough = function(control) {
     if (!L.Browser.touch) {


### PR DESCRIPTION
In order to avoid this
![grafik](https://user-images.githubusercontent.com/1151915/171402153-7d5a6544-e798-43ab-b257-34a52b84b5c7.png)
